### PR TITLE
fix Python dependency with default GNURadio install

### DIFF
--- a/gr-osmosdr.rb
+++ b/gr-osmosdr.rb
@@ -13,7 +13,32 @@ class GrOsmosdr < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      args = std_cmake_args
+
+      # From opencv.rb
+      python_prefix = `python-config --prefix`.strip
+      # Python is actually a library. The libpythonX.Y.dylib points to this lib, too.
+      if File.exist? "#{python_prefix}/Python"
+        # Python was compiled with --framework:
+        args << "-DPYTHON_LIBRARY='#{python_prefix}/Python'"
+        if !MacOS::CLT.installed? and python_prefix.start_with? '/System/Library'
+          # For Xcode-only systems, the headers of system's python are inside of Xcode
+          args << "-DPYTHON_INCLUDE_DIR='#{MacOS.sdk_path}/System/Library/Frameworks/Python.framework/Versions/2.7/Headers'"
+        else
+          args << "-DPYTHON_INCLUDE_DIR='#{python_prefix}/Headers'"
+        end
+      else
+        python_lib = "#{python_prefix}/lib/lib#{which_python}"
+        if File.exists? "#{python_lib}.a"
+          args << "-DPYTHON_LIBRARY='#{python_lib}.a'"
+        else
+          args << "-DPYTHON_LIBRARY='#{python_lib}.dylib'"
+        end
+        args << "-DPYTHON_INCLUDE_DIR='#{python_prefix}/include/#{which_python}'"
+      end
+      args << "-DPYTHON_PACKAGES_PATH='#{lib}/#{which_python}/site-packages'"
+
+      system "cmake", "..", *args
       system "make", "install"
     end
   end


### PR DESCRIPTION
To reproduce the problem, type:
  python -c "import osmosdr"

Crash happens without this patch