### PR TITLE
Update formula to resolve Brew's complaints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-homebrew-gr-osmosdr
-===================
+# homebrew-gr-osmosdr
+---
+
+Homebrew formula for gr-osmosdr
+
+### Installation
+
+```
+brew tap chleggett/homebrew-gr-osmosdr https://github.com/chleggett/homebrew-gr-osmosdr.git && brew install gr-osmosdr
+```
+
+Note: This formula depends on the `Cheetah` python module. Before installing this package, please `pip install Cheetah` on your system.

--- a/gr-osmosdr.rb
+++ b/gr-osmosdr.rb
@@ -6,9 +6,8 @@ class GrOsmosdr < Formula
   sha256 "59bb389431f72545f3ac51b87ceb98f3ba0591a1941f456ac4e67efb2ddb648c"
 
   depends_on "cmake" => :build
-  depends_on :python
+  depends_on "python"
   build.without? "python-deps"
-  depends_on "Cheetah" => :python
   depends_on "gnuradio"
 
   def install


### PR DESCRIPTION
I've resolved the following complaints from Brew about this formula: 

```
Warning: Calling 'depends_on :python' is deprecated!
Use 'depends_on "python"' instead.
/usr/local/Homebrew/Library/Taps/chleggett/homebrew-gr-osmosdr/gr-osmosdr.rb:9:in `<class:GrOsmosdr>'
Please report this to the chleggett/gr-osmosdr tap!

Warning: Calling 'depends_on ... => :python' is deprecated!
There is no replacement.
/usr/local/Homebrew/Library/Taps/chleggett/homebrew-gr-osmosdr/gr-osmosdr.rb:11:in `<class:GrOsmosdr>'
Please report this to the chleggett/gr-osmosdr tap!
```

Aside from the minor syntax adjustment on the python dependency, it seems that Brew no longer wishes to manage dependencies on language modules (more info [here](https://github.com/Homebrew/brew/blob/master/docs/Python-for-Formula-Authors.md)). 

As a result, I've removed the dependency on Cheetah, and instead updated README.md to reflect this dependency (so that the user knows to install Cheetah beforehand, via `pip`).

Thanks again for the great tap!